### PR TITLE
Comment and Posts now showing 'edited at' and specs to match

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,7 +80,7 @@ gem 'omniauth-twitter'
 gem 'omniauth-flickr', '>= 0.0.15'
 
 # client for Elasticsearch. Elasticsearch is a flexible
-# and powerful, distributed, real-time search and analytics engine. 
+# and powerful, distributed, real-time search and analytics engine.
 # An example of the use in the project is fuzzy crop search.
 gem "elasticsearch-model"
 gem "elasticsearch-rails"
@@ -119,6 +119,7 @@ group :development, :test do
   gem 'capybara-email'                  # integration tests for email
   gem 'poltergeist', '~> 1.5.1'         # for headless JS testing
   gem 'i18n-tasks'                      # adds tests for finding missing and unused translations
+  gem 'timecop'                         # freezes time to set created_at and updated_at for testing environment
 end
 
 group :travis do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,6 +368,7 @@ GEM
     thread (0.1.4)
     thread_safe (0.3.4)
     tilt (1.4.1)
+    timecop (0.7.1)
     tins (1.3.3)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -454,6 +455,7 @@ DEPENDENCIES
   ruby-units
   sass-rails (~> 4.0.4)
   therubyracer (~> 0.12)
+  timecop
   uglifier (~> 2.5.3)
   unicorn
   webrat

--- a/app/views/comments/_single.html.haml
+++ b/app/views/comments/_single.html.haml
@@ -9,6 +9,10 @@
           = link_to comment.author.login_name, member_path(comment.author)
           at
           = comment.created_at
+          %br
+          - if comment.updated_at > comment.created_at
+            edited at
+            = comment.updated_at
 
         .comment-body
           :growstuff_markdown

--- a/app/views/posts/_single.html.haml
+++ b/app/views/posts/_single.html.haml
@@ -16,6 +16,10 @@
               = link_to post.forum, post.forum
             at
             = post.created_at
+            %br
+            - if post.updated_at > post.created_at
+              edited at
+              = post.updated_at
 
         .post-body
           :growstuff_markdown

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 require 'simplecov'
 require 'coveralls'
+require 'byebug'
 
 # output coverage locally AND send it to coveralls
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[

--- a/spec/views/posts/_single.html.haml_spec.rb
+++ b/spec/views/posts/_single.html.haml_spec.rb
@@ -125,8 +125,12 @@ describe "posts/_single" do
       render_post
     end
 
-    it "shows edited at time after user has edited" do
+    it "shows edited at" do
       rendered.should have_content "edited at"
+    end
+
+    it "shows the updated time" do
+      rendered.should have_content @post.updated_at
     end
   end
 
@@ -143,6 +147,10 @@ describe "posts/_single" do
 
     it "shows edited at time after user has edited the comment" do
       rendered.should have_content "edited at"
+    end
+
+    it "shows updated time" do
+      rendered.should have_content @comment.updated_at
     end
   end
 

--- a/spec/views/posts/_single.html.haml_spec.rb
+++ b/spec/views/posts/_single.html.haml_spec.rb
@@ -160,7 +160,7 @@ describe "posts/_single" do
       sign_in @member
       controller.stub(:current_user) { @member }
       @post = FactoryGirl.create(:post, :author => @member)
-      @post.stub(updated_at: @post.created_at)
+      Timecop.freeze(@post.created_at = @post.updated_at)
       render_post
     end
 
@@ -175,12 +175,14 @@ describe "posts/_single" do
       sign_in @member
       controller.stub(:current_user) { @member }
       @post = FactoryGirl.create(:post, :author => @member)
+      rightnow = Timecop.freeze(Time.now)
       @comment = FactoryGirl.create(:comment, :post => @post)
-      @comment.stub(updated_at: @comment.created_at)
+      @comment.update(created_at: rightnow)
+      @comment.update(updated_at: rightnow)
       render_post
     end
 
-    it "does not show edited at time" do
+    it "does not show edited at" do
       rendered.should_not have_content "edited at #{@comment.updated_at}"
     end
   end

--- a/spec/views/posts/_single.html.haml_spec.rb
+++ b/spec/views/posts/_single.html.haml_spec.rb
@@ -142,7 +142,7 @@ describe "posts/_single" do
       @post = FactoryGirl.create(:post, :author => @member)
       @comment = FactoryGirl.create(:comment, :post => @post)
       @comment.update(body: "I've been updated")
-      render_post
+      render :partial => "comments/single", :locals => { :comment => @comment }
     end
 
     it "shows edited at time" do
@@ -175,11 +175,9 @@ describe "posts/_single" do
       sign_in @member
       controller.stub(:current_user) { @member }
       @post = FactoryGirl.create(:post, :author => @member)
-      rightnow = Timecop.freeze(Time.now)
       @comment = FactoryGirl.create(:comment, :post => @post)
-      @comment.update(created_at: rightnow)
-      @comment.update(updated_at: rightnow)
-      render_post
+      @comment.update(updated_at: @comment.created_at)
+      render :partial => "comments/single", :locals => { :comment => @comment }
     end
 
     it "does not show edited at" do

--- a/spec/views/posts/_single.html.haml_spec.rb
+++ b/spec/views/posts/_single.html.haml_spec.rb
@@ -145,12 +145,43 @@ describe "posts/_single" do
       render_post
     end
 
-    it "shows edited at time after user has edited the comment" do
+    it "shows edited at time" do
       rendered.should have_content "edited at"
     end
 
     it "shows updated time" do
       rendered.should have_content @comment.updated_at
+    end
+  end
+
+  context "when post has not been edited" do
+    before(:each) do
+      @member = FactoryGirl.create(:member)
+      sign_in @member
+      controller.stub(:current_user) { @member }
+      @post = FactoryGirl.create(:post, :author => @member)
+      @post.stub(updated_at: @post.created_at)
+      render_post
+    end
+
+    it "does not show edited at" do
+      rendered.should_not have_content "edited at #{@post.updated_at}"
+    end
+  end
+
+  context "when comment has not been edited" do
+    before(:each) do
+      @member = FactoryGirl.create(:member)
+      sign_in @member
+      controller.stub(:current_user) { @member }
+      @post = FactoryGirl.create(:post, :author => @member)
+      @comment = FactoryGirl.create(:comment, :post => @post)
+      @comment.stub(updated_at: @comment.created_at)
+      render_post
+    end
+
+    it "does not show edited at time" do
+      rendered.should_not have_content "edited at #{@comment.updated_at}"
     end
   end
 

--- a/spec/views/posts/_single.html.haml_spec.rb
+++ b/spec/views/posts/_single.html.haml_spec.rb
@@ -23,6 +23,7 @@ describe "posts/_single" do
     it "doesn't contain a link to new comment" do
       assert_select "a[href=#{new_comment_path(:post_id => @post.id)}]", false
     end
+
   end
 
   context "when logged in" do
@@ -113,8 +114,40 @@ describe "posts/_single" do
     end
 
   end
+
+  context "when post has been edited" do
+    before(:each) do
+      @member = FactoryGirl.create(:member)
+      sign_in @member
+      controller.stub(:current_user) { @member }
+      @post = FactoryGirl.create(:post, :author => @member)
+      @post.update(body: "I am updated")
+      render_post
+    end
+
+    it "shows edited at time after user has edited" do
+      rendered.should have_content "edited at"
+    end
+  end
+
+  context "when comment has been edited" do
+    before(:each) do
+      @member = FactoryGirl.create(:member)
+      sign_in @member
+      controller.stub(:current_user) { @member }
+      @post = FactoryGirl.create(:post, :author => @member)
+      @comment = FactoryGirl.create(:comment, :post => @post)
+      @comment.update(body: "I've been updated")
+      render_post
+    end
+
+    it "shows edited at time after user has edited the comment" do
+      rendered.should have_content "edited at"
+    end
+  end
+
 end
 
 
 
- 
+


### PR DESCRIPTION
All specs are in the 'spec/views/post/_single.html.haml.rb' file - should be split into post and comment view directories
